### PR TITLE
Add open-world environment

### DIFF
--- a/bots.js
+++ b/bots.js
@@ -1,0 +1,39 @@
+import * as THREE from 'three';
+import { addToScene } from './main.js';
+import { spawnPos } from './player.js';
+
+const bots = [];
+
+export function initBots() {
+    const colors = [
+        0xff0000, 0x00ff00, 0x0000ff, 0xffff00,
+        0xff00ff, 0x00ffff, 0xff8800, 0x88ff00,
+        0x0088ff, 0xff0088, 0x8800ff, 0x00ff88
+    ];
+    for (let i = 0; i < 12; i++) {
+        const geo = new THREE.CylinderGeometry(0.5, 0.5, 2, 12);
+        const mat = new THREE.MeshStandardMaterial({ color: colors[i % colors.length] });
+        const mesh = new THREE.Mesh(geo, mat);
+        mesh.castShadow = true;
+        mesh.position.set(
+            spawnPos.x + (Math.random() - 0.5) * 80,
+            1,
+            spawnPos.z + (Math.random() - 0.5) * 80
+        );
+        addToScene(mesh);
+        bots.push({ mesh, aggression: Math.random() });
+    }
+}
+
+export function updateBots(delta, playerPos) {
+    const tmp = new THREE.Vector3();
+    for (const bot of bots) {
+        tmp.copy(playerPos).sub(bot.mesh.position);
+        tmp.y = 0;
+        const distToPlayer = tmp.length();
+        if (distToPlayer > 0.001) tmp.normalize();
+        const randomDir = new THREE.Vector3(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
+        tmp.multiplyScalar(bot.aggression).add(randomDir.multiplyScalar(1 - bot.aggression)).normalize();
+        bot.mesh.position.addScaledVector(tmp, 5 * delta);
+    }
+}

--- a/bots.js
+++ b/bots.js
@@ -22,6 +22,7 @@ export function initBots() {
             1,
             spawnPos.z + (Math.random() - 0.5) * 80
         );
+        mesh.velocity = new THREE.Vector3();
         addToScene(mesh);
         bots.push({ mesh, aggression: Math.random() });
         collidableObjects.push(mesh);
@@ -57,6 +58,7 @@ function checkCollision(mesh, newPos) {
     botBox.applyMatrix4(new THREE.Matrix4().makeTranslation(newPos.x, newPos.y, newPos.z));
     for (const obj of collidableObjects) {
         if (obj === mesh) continue;
+        if (obj.userData && obj.userData.isGround) continue; // allow sliding on floor
         if (!obj.geometry || !obj.geometry.boundingBox) obj.geometry?.computeBoundingBox?.();
         if (!obj.geometry?.boundingBox) continue;
         const objBox = obj.geometry.boundingBox.clone();

--- a/bots.js
+++ b/bots.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { addToScene } from './main.js';
 import { spawnPos } from './player.js';
+import { collidableObjects } from './physics.js';
 
 const bots = [];
 
@@ -12,6 +13,7 @@ export function initBots() {
     ];
     for (let i = 0; i < 12; i++) {
         const geo = new THREE.CylinderGeometry(0.5, 0.5, 2, 12);
+        geo.computeBoundingBox();
         const mat = new THREE.MeshStandardMaterial({ color: colors[i % colors.length] });
         const mesh = new THREE.Mesh(geo, mat);
         mesh.castShadow = true;
@@ -22,18 +24,46 @@ export function initBots() {
         );
         addToScene(mesh);
         bots.push({ mesh, aggression: Math.random() });
+        collidableObjects.push(mesh);
     }
 }
 
 export function updateBots(delta, playerPos) {
     const tmp = new THREE.Vector3();
+    const proposed = new THREE.Vector3();
     for (const bot of bots) {
         tmp.copy(playerPos).sub(bot.mesh.position);
         tmp.y = 0;
         const distToPlayer = tmp.length();
         if (distToPlayer > 0.001) tmp.normalize();
         const randomDir = new THREE.Vector3(Math.random() - 0.5, 0, Math.random() - 0.5).normalize();
-        tmp.multiplyScalar(bot.aggression).add(randomDir.multiplyScalar(1 - bot.aggression)).normalize();
-        bot.mesh.position.addScaledVector(tmp, 5 * delta);
+        const moveDir = tmp.multiplyScalar(bot.aggression).add(randomDir.multiplyScalar(1 - bot.aggression)).normalize();
+
+        proposed.copy(bot.mesh.position).addScaledVector(moveDir, 5 * delta);
+        if (!checkCollision(bot.mesh, proposed)) {
+            bot.mesh.position.copy(proposed);
+        } else {
+            const sideDir = new THREE.Vector3(moveDir.z, 0, -moveDir.x); // rotate 90 degrees
+            proposed.copy(bot.mesh.position).addScaledVector(sideDir, 5 * delta);
+            if (!checkCollision(bot.mesh, proposed)) {
+                bot.mesh.position.copy(proposed);
+            }
+        }
     }
+}
+
+function checkCollision(mesh, newPos) {
+    const botBox = mesh.geometry.boundingBox.clone();
+    botBox.applyMatrix4(new THREE.Matrix4().makeTranslation(newPos.x, newPos.y, newPos.z));
+    for (const obj of collidableObjects) {
+        if (obj === mesh) continue;
+        if (!obj.geometry || !obj.geometry.boundingBox) obj.geometry?.computeBoundingBox?.();
+        if (!obj.geometry?.boundingBox) continue;
+        const objBox = obj.geometry.boundingBox.clone();
+        objBox.applyMatrix4(obj.matrixWorld);
+        if (botBox.intersectsBox(objBox)) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/bots.js
+++ b/bots.js
@@ -6,9 +6,9 @@ const bots = [];
 
 export function initBots() {
     const colors = [
-        0xff0000, 0x00ff00, 0x0000ff, 0xffff00,
-        0xff00ff, 0x00ffff, 0xff8800, 0x88ff00,
-        0x0088ff, 0xff0088, 0x8800ff, 0x00ff88
+        0xff4444, 0x44ff44, 0x4444ff, 0xffff44,
+        0xff44ff, 0x44ffff, 0xff8844, 0x88ff44,
+        0x4488ff, 0xff4488, 0x8844ff, 0x44ff88
     ];
     for (let i = 0; i < 12; i++) {
         const geo = new THREE.CylinderGeometry(0.5, 0.5, 2, 12);

--- a/controls.js
+++ b/controls.js
@@ -45,6 +45,8 @@ export function controlsinit(camera, renderer) {
     // Initialize controls
     const controls = new PointerLockControls(camera, document.body);
 
+    controls.velocity = new THREE.Vector3(); 
+
     // Hide context menu on right-click
     document.addEventListener('contextmenu', (event) => {
         event.preventDefault();

--- a/environment_open.js
+++ b/environment_open.js
@@ -1,0 +1,67 @@
+// Open world environment with scattered obstacles
+import * as THREE from 'three';
+import { collidableObjects } from './physics.js';
+import { addToScene } from './main.js';
+import { spawnPos } from './player.js';
+
+// Place player near the center of the world
+spawnPos.set(0, 0, 5);
+
+export function environmentinit() {
+    // Directional light for the scene
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 5);
+    directionalLight.position.set(50, 100, 50);
+    directionalLight.castShadow = true;
+    directionalLight.shadow.mapSize.width = 4096;
+    directionalLight.shadow.mapSize.height = 4096;
+    directionalLight.shadow.camera.near = 1;
+    directionalLight.shadow.camera.far = 250;
+    directionalLight.shadow.camera.left = -125;
+    directionalLight.shadow.camera.right = 125;
+    directionalLight.shadow.camera.top = 125;
+    directionalLight.shadow.camera.bottom = -125;
+    addToScene(directionalLight);
+
+    // Textures for the ground
+    const floorTexture = new THREE.TextureLoader().load('Textures/granite_tile_diff_4k.jpg');
+    const floorDisp = new THREE.TextureLoader().load('Textures/granite_tile_disp_4k.jpg');
+    const floorRough = new THREE.TextureLoader().load('Textures/granite_tile_rough_4k.jpg');
+
+    floorTexture.wrapS = floorTexture.wrapT = THREE.RepeatWrapping;
+    floorTexture.repeat.set(40, 40);
+    floorDisp.wrapS = floorDisp.wrapT = THREE.RepeatWrapping;
+    floorDisp.repeat.set(40, 40);
+    floorRough.wrapS = floorRough.wrapT = THREE.RepeatWrapping;
+    floorRough.repeat.set(40, 40);
+
+    // Large open floor
+    const floorGeometry = new THREE.BoxGeometry(200, 0.5, 200);
+    const floorMaterial = new THREE.MeshStandardMaterial({
+        map: floorTexture,
+        bumpMap: floorDisp,
+        roughnessMap: floorRough
+    });
+    const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+    floor.receiveShadow = true;
+    floor.position.y = -0.25;
+    collidableObjects.push(floor);
+    addToScene(floor);
+
+    // Simple randomly scattered obstacles
+    const colors = [0x808080, 0x999999, 0x777777];
+    for (let i = 0; i < 25; i++) {
+        const size = 1 + Math.random() * 3;
+        const geo = new THREE.BoxGeometry(size, size, size);
+        const mat = new THREE.MeshStandardMaterial({ color: colors[i % colors.length] });
+        const box = new THREE.Mesh(geo, mat);
+        box.castShadow = true;
+        box.receiveShadow = true;
+        box.position.set(
+            (Math.random() - 0.5) * 180,
+            size / 2,
+            (Math.random() - 0.5) * 180
+        );
+        collidableObjects.push(box);
+        addToScene(box);
+    }
+}

--- a/environment_open.js
+++ b/environment_open.js
@@ -44,6 +44,7 @@ export function environmentinit() {
     const floor = new THREE.Mesh(floorGeometry, floorMaterial);
     floor.receiveShadow = true;
     floor.position.y = -0.25;
+    floor.userData.isGround = true; // flag to ignore in bot collisions
     collidableObjects.push(floor);
     addToScene(floor);
 

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ import {sceneinit} from './scene.js';
 import {controlsinit, moveControls, zoomControls} from './controls.js';
 import { addPlayerToScene, spawnPos } from './player.js';
 import { updatePhysics } from './physics.js';
-import {environmentinit} from './environment.js';
+import {environmentinit} from './environment_open.js';
 import { originalFOV, zoomDuration, zoomedFOV } from './shootzoom.js';
 
 const clock = new THREE.Clock();

--- a/main.js
+++ b/main.js
@@ -60,9 +60,9 @@ function animate() {
 
 
         updatePhysics(delta, camera, controls);
+        updateBots(delta, camera.position);
     }
 
-    updateBots(delta, camera.position);
 
     
     /* Rotate the cube for some animation

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ import {controlsinit, moveControls, zoomControls} from './controls.js';
 import { addPlayerToScene, spawnPos } from './player.js';
 import { updatePhysics } from './physics.js';
 import {environmentinit} from './environment_open.js';
+import { initBots, updateBots } from './bots.js';
 import { originalFOV, zoomDuration, zoomedFOV } from './shootzoom.js';
 
 const clock = new THREE.Clock();
@@ -22,6 +23,7 @@ export function addToScene(obj){
 
 addPlayerToScene();
 environmentinit();
+initBots();
 animate();
 
 function animate() {
@@ -59,6 +61,8 @@ function animate() {
 
         updatePhysics(delta, camera, controls);
     }
+
+    updateBots(delta, camera.position);
 
     
     /* Rotate the cube for some animation

--- a/main.js
+++ b/main.js
@@ -60,9 +60,8 @@ function animate() {
 
 
         updatePhysics(delta, camera, controls);
+        updateBots(delta, camera.position);
     }
-
-    updateBots(delta, camera.position);
 
     
     /* Rotate the cube for some animation

--- a/physics.js
+++ b/physics.js
@@ -14,13 +14,13 @@ const zoomedSpeed = 40.0;
 const inAirSpeed = 8.0;
 
 const gravity = 25;
-const jumpHeight = 0; // Default 12
+const jumpHeight = 10; // Default 12
 const thrustHeight = 45; // Fighting gravity
 let movementSpeed = walkSpeed;
 const dampingFactor = 0.18;
 let damping = Math.exp(-dampingFactor);
 let verticalDrag = Math.exp(-.008);
-const velocity = new THREE.Vector3();
+const velocity = new THREE.Vector3(); // Velocity of the player
 const minimumVelocity = 0.01; // velocity will be 0 below this
 const direction = new THREE.Vector3();
 const cameraDir = new THREE.Vector3();
@@ -37,7 +37,7 @@ export function updatePhysics(delta, camera, controls) {
     // Jumping
     if (moveControls.jumping) {
         moveControls.jumping = false;
-        velocity.y += jumpHeight;
+        controls.velocity.y += jumpHeight;
         moveControls.canJump = false;
         damping = 1.0; // Disable friction while in the air
         movementSpeed = inAirSpeed;
@@ -45,20 +45,28 @@ export function updatePhysics(delta, camera, controls) {
 
     // Jetpack
     if (moveControls.thrust) {
-        velocity.y += thrustHeight * delta;
+        moveControls.jumping = false;
+        moveControls.canJump = false;
+        controls.velocity.y += thrustHeight * delta;
         damping = 1.0; // Enable drag while in the air
         movementSpeed = inAirSpeed;
     }
 
-    // Apply gravity
-    velocity.y -= gravity * delta;
+    // Apply gravity for player
+    controls.velocity.y -= gravity * delta;
+
+    // Apply gravity for all collidable objects
+    for (const obj in collidableObjects){
+        if(obj.hasOwnProperty('velocity'))
+            obj.velocity.y -= gravity * delta;
+    }
 
     // Apply friction
     if (Math.abs(velocity.x) < minimumVelocity) velocity.x = 0; else velocity.x *= damping;
     if (Math.abs(velocity.z) < minimumVelocity) velocity.z = 0; else velocity.z *= damping;
 
     // Apply air drag
-    if (Math.abs(velocity.y) < minimumVelocity) velocity.y = 0; else velocity.y *= verticalDrag;
+    if (Math.abs(controls.velocity.y) < minimumVelocity) controls.velocity.y = 0; else controls.velocity.y *= verticalDrag;
 
     // Determine movement direction from keys
     direction.set(0, 0, 0);
@@ -83,7 +91,7 @@ export function updatePhysics(delta, camera, controls) {
     // Move the camera
     controls.object.position.x += velocity.x * delta;
     controls.object.position.z += velocity.z * delta;
-    controls.object.position.y += velocity.y * delta;
+    controls.object.position.y += controls.velocity.y * delta;
 
     // Reset if out of bounds
     if (controls.object.position.y < -200) {
@@ -143,12 +151,12 @@ function resolveCollision(objectBBox, controls) {
     } else if (overlap.y < overlap.x && overlap.y < overlap.z) {
         if (controls.object.position.y > objectBBox.getCenter(new THREE.Vector3()).y) {
             controls.object.position.y += overlap.y;
-            velocity.y = 0;
+            controls.velocity.y = 0;
             moveControls.canJump = true;
             damping = Math.exp(-dampingFactor);
         } else {
             controls.object.position.y -= overlap.y;
-            velocity.y = 0;
+            controls.velocity.y = 0;
         }
     } else {
         if (controls.object.position.z > objectBBox.getCenter(new THREE.Vector3()).z) {


### PR DESCRIPTION
## Summary
- create `environment_open.js` for a large flat map with scattered obstacles
- load this new environment in `main.js`

## Testing
- `node --check environment_open.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68747ecd9360833198ef5c5a98c93bb9